### PR TITLE
Revert "Use return {} instead of explicit ctor calls"

### DIFF
--- a/include/noarr/structures/state.hpp
+++ b/include/noarr/structures/state.hpp
@@ -97,7 +97,7 @@ struct state : contain<typename StateItems::value_type...> {
 
 	template<class... NewStateItems>
 	constexpr state<NewStateItems...> restrict(helpers::state_items_pack<NewStateItems...> = {}) const noexcept {
-		return {get<typename NewStateItems::tag>()...};
+		return state<NewStateItems...>(get<typename NewStateItems::tag>()...);
 	}
 
 	template<class... Tags>
@@ -112,7 +112,7 @@ struct state : contain<typename StateItems::value_type...> {
 
 	template<class... NewStateItems>
 	constexpr state<StateItems..., NewStateItems...> merge(const state<NewStateItems...> &other) const noexcept {
-		return {get<typename StateItems::tag>()..., other.template get<typename NewStateItems::tag>()...};
+		return state<StateItems..., NewStateItems...>(get<typename StateItems::tag>()..., other.template get<typename NewStateItems::tag>()...);
 	}
 };
 

--- a/include/noarr/structures/struct_decls.hpp
+++ b/include/noarr/structures/struct_decls.hpp
@@ -94,7 +94,7 @@ struct compose_proto : contain<InnerProtoStruct, OuterProtoStruct> {
 
 template<class InnerProtoStruct, class OuterProtoStruct>
 constexpr compose_proto<InnerProtoStruct, OuterProtoStruct> operator ^(InnerProtoStruct i, OuterProtoStruct o) {
-	return {i, o};
+	return compose_proto(i, o);
 }
 
 } // namespace noarr

--- a/include/noarr/structures/traverser.hpp
+++ b/include/noarr/structures/traverser.hpp
@@ -156,7 +156,7 @@ private:
 };
 
 template<class... Ts, class U = union_t<typename to_struct<Ts>::type...>>
-constexpr traverser_t<U, neutral_proto> traverser(const Ts &... s) noexcept { return {U(to_struct<Ts>::convert(s)...), neutral_proto()}; }
+constexpr traverser_t<U, neutral_proto> traverser(const Ts &... s) noexcept { return traverser_t<U, neutral_proto>(U(to_struct<Ts>::convert(s)...), neutral_proto()); }
 
 } // namespace noarr
 

--- a/include/noarr/structures/wrapper.hpp
+++ b/include/noarr/structures/wrapper.hpp
@@ -128,7 +128,7 @@ public:
 
 template<class Structure>
 constexpr wrapper<Structure> wrap(Structure s) noexcept {
-	return {s};
+	return wrapper<Structure>(s);
 }
 
 /**


### PR DESCRIPTION
Reverts jiriklepl/noarr-structures#3